### PR TITLE
An important update

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ int openat_handle(struct handler_args* _handler_args) {
   char buf_tmp[ARGS_BUF_SIZE + 1];
 
   assemble_buf_arg(buf_tmp, pathname, ARGS_BUF_SIZE);
-  sprintf(_handler_args->small_buf,
+  fast_sprintf(_handler_args->small_buf,
           "pid=%d, openat, dir=%d, path=%s, flags=%d, mode=%u, "
           "res=%d\n",
           current->pid, dirfd, buf_tmp, flags, mode, (int)_handler_args->ret);

--- a/core-hook.h
+++ b/core-hook.h
@@ -77,7 +77,7 @@ TRACEPOINT_PROBE(syscall_exit_probe, struct pt_regs *regs, long ret) {
 
   record_partial_flag = gen_record_str(&_handler_args);
   if (record_partial_flag != -1) {
-    len = strlen(_handler_args.small_buf);
+    len = strlen(small_buf);
     WRITE_FILE_LOCK();
     if (!check_offset(len)) {
       transfer_to_real_of_real_buffer();

--- a/core-hook.h
+++ b/core-hook.h
@@ -55,7 +55,7 @@ TRACEPOINT_PROBE(syscall_exit_probe, struct pt_regs *regs, long ret) {
   int record_partial_flag = 0;
   // char *name = get_process_name();
   unsigned long len;
-  // bool should_write_flag = false;
+  bool should_real_dump_file = false;
 
   if (check_proc(pid, proc_name, ppid, parent_proc_name) == 0) {
     return;
@@ -81,11 +81,16 @@ TRACEPOINT_PROBE(syscall_exit_probe, struct pt_regs *regs, long ret) {
     len = strlen(small_buf);
     WRITE_FILE_LOCK();
     if (!check_offset(len)) {
-      dump_to_file();
+      transfer_to_real_of_real_buffer();
+      should_real_dump_file = true;
     }
     write_something_to_buffer(small_buf, len);
     syscall_count++;
     WRITE_FILE_UNLOCK();
+  }
+
+  if(should_real_dump_file){
+    dump_real_of_real_buffer();
   }
 }
 

--- a/core-hook.h
+++ b/core-hook.h
@@ -36,14 +36,14 @@ TRACEPOINT_PROBE(syscall_enter_probe, struct pt_regs *regs, long id) {
   }
 
 #ifdef ENABLE_LOCK
-  spin_lock(&hashtable_lock);
+  spin_lock_irq(&hashtable_lock);
 #endif
   // write_something_to_buffer(small_buf, len);
   hashtable_put(&proc_arg0_hash_table, current->pid,
                 (HASH_TABLE_ENTER){id, get_arg0(regs), get_arg1(regs)});
   syscall_count++;
 #ifdef ENABLE_LOCK
-  spin_unlock(&hashtable_lock);
+  spin_unlock_irq(&hashtable_lock);
 #endif
 }
 
@@ -61,7 +61,7 @@ TRACEPOINT_PROBE(syscall_exit_probe, struct pt_regs *regs, long ret) {
   }
 
 #ifdef ENABLE_LOCK
-  spin_lock(&hashtable_lock);
+  spin_lock_irq(&hashtable_lock);
 #endif
   // get the info from hash table
   _handler_args.saved_entry =
@@ -72,7 +72,7 @@ TRACEPOINT_PROBE(syscall_exit_probe, struct pt_regs *regs, long ret) {
 
   // gen_record_str(small_buf, regs, syscall_no, arg0);
 #ifdef ENABLE_LOCK
-  spin_unlock(&hashtable_lock);
+  spin_unlock_irq(&hashtable_lock);
 #endif
 
   record_partial_flag = gen_record_str(&_handler_args);

--- a/core-hook.h
+++ b/core-hook.h
@@ -55,7 +55,6 @@ TRACEPOINT_PROBE(syscall_exit_probe, struct pt_regs *regs, long ret) {
   int record_partial_flag = 0;
   // char *name = get_process_name();
   unsigned long len;
-  bool should_real_dump_file = false;
 
   if (check_proc(pid, proc_name, ppid, parent_proc_name) == 0) {
     return;
@@ -82,15 +81,11 @@ TRACEPOINT_PROBE(syscall_exit_probe, struct pt_regs *regs, long ret) {
     WRITE_FILE_LOCK();
     if (!check_offset(len)) {
       transfer_to_real_of_real_buffer();
-      should_real_dump_file = true;
     }
     write_something_to_buffer(small_buf, len);
     syscall_count++;
     WRITE_FILE_UNLOCK();
-  }
-
-  if(should_real_dump_file){
-    dump_real_of_real_buffer();
+    try_dump_real_buffer();
   }
 }
 

--- a/core-hook.h
+++ b/core-hook.h
@@ -76,8 +76,8 @@ TRACEPOINT_PROBE(syscall_exit_probe, struct pt_regs *regs, long ret) {
 #endif
 
   record_partial_flag = gen_record_str(&_handler_args);
-  if (record_partial_flag == 0) {
-    len = strlen(small_buf);
+  if (record_partial_flag != -1) {
+    len = strlen(_handler_args.small_buf);
     WRITE_FILE_LOCK();
     if (!check_offset(len)) {
       transfer_to_real_of_real_buffer();
@@ -85,6 +85,12 @@ TRACEPOINT_PROBE(syscall_exit_probe, struct pt_regs *regs, long ret) {
     write_something_to_buffer(small_buf, len);
     syscall_count++;
     WRITE_FILE_UNLOCK();
+  }
+
+  if(record_partial_flag == 0){
+    if(should_real_dump_file){
+      printk("should? %s",small_buf);
+    }
     try_dump_real_buffer();
   }
 }

--- a/dump-file.h
+++ b/dump-file.h
@@ -46,7 +46,7 @@ int file_write(struct file* file, const char* data, unsigned int size) {
   // set_fs(get_ds());
   set_fs(KERNEL_DS);
 
-  ret = kernel_write(file, data, size, &__file_to_record->f_pos);
+  ret = kernel_write(file, data, size, &file->f_pos);
 
   set_fs(oldfs);
   return ret;

--- a/dump-file.h
+++ b/dump-file.h
@@ -57,8 +57,8 @@ int file_write(struct file* file, const char* data, unsigned int size) {
 static void save_to_file(const char* src, const u32 len) {
   static unsigned long times = 0;
   static long index = -1;
-  // static const unsigned long LIMIT = (1UL << 31) / BUF_SIZE - 1;
-  static const unsigned long LIMIT = 3;
+  static const unsigned long LIMIT = (1UL << 31) / BUF_SIZE - 1;
+  // static const unsigned long LIMIT = 3;
   times++;
   printk("times: %ld, index: %ld", times, index);
   if (times >= LIMIT) {

--- a/my_sysdig.c
+++ b/my_sysdig.c
@@ -47,6 +47,7 @@ static int __init my_sysdig_init(void) {
   open_record_file("/etc/syscall-record/record");
   spin_lock_init(&buf_lock);
   spin_lock_init(&hashtable_lock);
+  spin_lock_init(&try_dump_real_file_lock);
 
   register_syscall_hook();
   // then print out the filter condition

--- a/my_sysdig.c
+++ b/my_sysdig.c
@@ -36,7 +36,7 @@ static void __exit my_sysdig_exit(void) {
 #ifdef MYSYSDIG_DEBUG
   dump_buffer();
 #endif
-  dump_to_file();
+  transfer_to_real_of_real_buffer();
   cleanup();
   close_record_file();
   printk("[my_sysdig:] remove my_sysdig successfully");

--- a/record-buffer.h
+++ b/record-buffer.h
@@ -38,7 +38,7 @@ static void transfer_to_real_of_real_buffer(void) {
   //     "it is time to dump records to file with offset: %ld, current stat:
   //     %lld", real_offset, syscall_count);
   // save_to_file(real_buffer, real_offset);
-  strncpy(real_of_real_buffer, real_buffer, real_offset);
+  memcpy(real_of_real_buffer, real_buffer, real_offset);
   real_of_real_length = real_offset;
   should_real_dump_file = true;
   real_offset = 0;
@@ -63,7 +63,7 @@ static inline void try_dump_real_buffer(void) {
 static void write_something_to_buffer(const char* src,
                                       const unsigned long str_len) {
   unsigned long offset_end = real_offset + str_len;
-  strncpy(real_buffer + real_offset, src, str_len);
+  memcpy(real_buffer + real_offset, src, str_len);
   real_offset = offset_end;
 }
 
@@ -71,7 +71,7 @@ static void __attribute__((unused))
 write_something_to_buffer_from_user(const char* src,
                                     const unsigned long str_len) {
   unsigned long offset_end = real_offset + str_len;
-  strncpy_from_user(real_buffer + real_offset, src, str_len);
+  copy_from_user(real_buffer + real_offset, src, str_len);
   real_offset = offset_end;
 }
 

--- a/record-buffer.h
+++ b/record-buffer.h
@@ -75,16 +75,4 @@ write_something_to_buffer_from_user(const char* src,
   real_offset = offset_end;
 }
 
-// static void dump_buffer(void) {
-//   unsigned long offset = 0;
-//   unsigned long a;
-//   while (1) {
-//     printk("%s\n", real_buffer + offset);
-//     a = strlen(real_buffer + offset);
-//     if (a == 0) {
-//       break;
-//     }
-//     offset += a + 1;
-//   }
-// }
 #endif

--- a/record-buffer.h
+++ b/record-buffer.h
@@ -25,6 +25,8 @@ char real_buffer[BUF_SIZE];
 char real_of_real_buffer[BUF_SIZE];
 unsigned long real_offset = 0;
 unsigned long real_of_real_length = 0;
+bool should_real_dump_file = false;
+spinlock_t try_dump_real_file_lock;
 
 extern u64 syscall_count;
 static bool check_offset(unsigned long str_len) {
@@ -39,11 +41,23 @@ static void transfer_to_real_of_real_buffer(void) {
   // save_to_file(real_buffer, real_offset);
   strncpy(real_of_real_buffer, real_buffer, real_offset);
   real_of_real_length = real_offset;
+  should_real_dump_file = true;
   real_offset = 0;
 }
 
 static inline void dump_real_of_real_buffer(void) {
   save_to_file(real_of_real_buffer, real_of_real_length);
+}
+
+static inline void try_dump_real_buffer(void) {
+  if (should_real_dump_file) {
+    spin_lock(&try_dump_real_file_lock);
+    if (should_real_dump_file) {
+      should_real_dump_file = false;
+      dump_real_of_real_buffer();
+    }
+    spin_unlock(&try_dump_real_file_lock);
+  }
 }
 
 static void write_something_to_buffer(const char* src,

--- a/record-buffer.h
+++ b/record-buffer.h
@@ -19,7 +19,7 @@
 #define PAGE_ORDER 2
 /* this value can get from PAGE_ORDER */
 #define PAGES_NUMBER 4
-#define BUF_SIZE (1024 * 1024 * 8)  // 8M
+#define BUF_SIZE (1024 * 1024 * 16)  // 16M
 
 char real_buffer[BUF_SIZE];
 char real_of_real_buffer[BUF_SIZE];

--- a/record-buffer.h
+++ b/record-buffer.h
@@ -19,7 +19,6 @@
 #define PAGE_ORDER 2
 /* this value can get from PAGE_ORDER */
 #define PAGES_NUMBER 4
-#define BUF_SIZE (1024 * 1024 * 16)  // 16M
 
 char real_buffer[BUF_SIZE];
 char real_of_real_buffer[BUF_SIZE];
@@ -51,6 +50,7 @@ static inline void dump_real_of_real_buffer(void) {
 
 static inline void try_dump_real_buffer(void) {
   if (should_real_dump_file) {
+    // !!! spin_lock seems work on x86
     spin_lock(&try_dump_real_file_lock);
     if (should_real_dump_file) {
       should_real_dump_file = false;

--- a/record-buffer.h
+++ b/record-buffer.h
@@ -22,20 +22,28 @@
 #define BUF_SIZE (1024 * 1024 * 8)  // 8M
 
 char real_buffer[BUF_SIZE];
-
+char real_of_real_buffer[BUF_SIZE];
 unsigned long real_offset = 0;
+unsigned long real_of_real_length = 0;
+
 extern u64 syscall_count;
 static bool check_offset(unsigned long str_len) {
   return real_offset + str_len < BUF_SIZE;
 }
 
-static void dump_to_file(void) {
+static void transfer_to_real_of_real_buffer(void) {
   // definitely needs a lock when call it...
   // printk(
   //     "it is time to dump records to file with offset: %ld, current stat:
   //     %lld", real_offset, syscall_count);
-  save_to_file(real_buffer, real_offset);
+  // save_to_file(real_buffer, real_offset);
+  strncpy(real_of_real_buffer, real_buffer, real_offset);
+  real_of_real_length = real_offset;
   real_offset = 0;
+}
+
+static inline void dump_real_of_real_buffer(void) {
+  save_to_file(real_of_real_buffer, real_of_real_length);
 }
 
 static void write_something_to_buffer(const char* src,

--- a/syscalls/__fast_sprintf.h
+++ b/syscalls/__fast_sprintf.h
@@ -1,0 +1,128 @@
+#ifndef MYSYSDIG_FAST_SPRINTF_H
+#define MYSYSDIG_FAST_SPRINTF_H
+#include <stdarg.h>
+
+static char *my_sprintf_assemble_string(char *dst_buf, const char *str) {
+  char *tmp = (char *)str;
+  while (*tmp != '\0') {
+    *dst_buf = *tmp;
+    dst_buf++;
+    tmp++;
+  }
+  return dst_buf;
+}
+
+typedef union {
+  unsigned long long _unsigned_long_val;
+  long long _long_val;
+  int _int_val;
+  unsigned _unsigned_val;
+} _number;
+
+static char *my_sprintf_assemble_number(char *dst_buf, _number var,
+                                       const short base, const bool singed,
+                                       const bool is_32) {
+  static char sta[35];
+  static const char c20[] = "0123456789abcdef";
+  int top = 0;
+  bool neg_flag = false;
+  if (singed) {
+    if (is_32) {
+      if (var._int_val < 0) {
+        var._int_val = -var._int_val;
+        neg_flag = true;
+      }
+      do {
+        sta[top++] = c20[var._int_val % base];
+        var._int_val /= base;
+      } while (var._int_val);
+    } else {
+      if (var._long_val < 0) {
+        var._long_val = -var._long_val;
+        neg_flag = true;
+      }
+      do {
+        sta[top++] = c20[var._long_val % base];
+        var._long_val /= base;
+      } while (var._long_val);
+    }
+    if (neg_flag) {
+      sta[top++] = '-';
+    }
+  } else {
+    if (is_32) {
+      do {
+        sta[top++] = c20[var._unsigned_val % base];
+        var._unsigned_val /= base;
+      } while (var._unsigned_val);
+    } else {
+      do {
+        sta[top++] = c20[var._unsigned_long_val % base];
+        var._unsigned_long_val /= base;
+      } while (var._unsigned_long_val);
+    }
+  }
+  while (top) {
+    *dst_buf = sta[--top];
+    dst_buf++;
+  }
+  return dst_buf;
+}
+
+int fast_sprintf(char *dst_buf, char *format, ...) {
+  va_list args;
+  int format_cnt = 0;
+  _number num;
+  va_start(args, format);
+
+  while (*format != '\0') {
+    if (*format == '%') {
+      format++;
+      if (*format == 'l') {
+        format++;
+        if (*format == 'd') {
+          num._long_val = va_arg(args, long);
+          dst_buf = my_sprintf_assemble_number(dst_buf, num, 10, true, false);
+        } else if (*format == 'u') {
+          num._unsigned_val = va_arg(args, unsigned long);
+          dst_buf = my_sprintf_assemble_number(dst_buf, num, 10, false, false);
+        } else if (*format == 'x') {
+          num._long_val = va_arg(args, long);
+          dst_buf = my_sprintf_assemble_number(dst_buf, num, 16, false, false);
+        } else {
+          // unsupported
+          format_cnt--;
+        }
+      } else if (*format == 'd') {
+        num._int_val = va_arg(args, int);
+        dst_buf = my_sprintf_assemble_number(dst_buf, num, 10, true, true);
+      } else if (*format == 'u') {
+        num._unsigned_val = va_arg(args, unsigned);
+        dst_buf = my_sprintf_assemble_number(dst_buf, num, 10, false, true);
+      } else if (*format == 'p') {
+        // base 16
+        num._unsigned_val = (unsigned long)va_arg(args, void *);
+        dst_buf = my_sprintf_assemble_number(dst_buf, num, 16, false, true);
+      } else if (*format == 'x') {
+        num._int_val = va_arg(args, int);
+        dst_buf = my_sprintf_assemble_number(dst_buf, num, 16, false, true);
+      } else if (*format == 's') {
+        dst_buf = my_sprintf_assemble_string(dst_buf, va_arg(args, char *));
+      } else {
+        // unsupported
+        format_cnt--;
+      }
+      format_cnt++;
+    } else {
+      *dst_buf = *format;
+      dst_buf++;
+    }
+    // *format = *format + 1;
+    format++;
+  }
+  va_end(args);
+  *dst_buf = '\0';
+  return format_cnt;
+}
+
+#endif

--- a/syscalls/arch.h
+++ b/syscalls/arch.h
@@ -4,7 +4,7 @@
 #include "__x86_64.h"
 #include "handlers-table.h"
 #include "handlers.h"
-
+#include "__fast_sprintf.h"
 
 
 inline unsigned long get_arg0(struct pt_regs* regs) {
@@ -78,6 +78,21 @@ inline unsigned long get_arg5(struct pt_regs* regs) {
   return -1;
 #endif
 }
+
+
+inline unsigned long get_return_address(struct pt_regs* regs) {
+#ifdef CONFIG_X86
+// NOT IMPLEMENTED FOR x86
+  return 0;
+#elif defined(CONFIG_ARM64)
+  return regs->regs[30];
+#elif defined(CONFIG_RISCV)
+  return regs->ra;
+#else
+  return -1;
+#endif
+}
+
 
 extern char syscall_id_to_name[][32];
 extern handler_callback syscall_id_handlers[512];

--- a/syscalls/arch.h
+++ b/syscalls/arch.h
@@ -1,11 +1,10 @@
 #ifndef _MYSYSDIG_ALL_ARCH
 #define _MYSYSDIG_ALL_ARCH
 #include "__arm64.h"
+#include "__fast_sprintf.h"
 #include "__x86_64.h"
 #include "handlers-table.h"
 #include "handlers.h"
-#include "__fast_sprintf.h"
-
 
 inline unsigned long get_arg0(struct pt_regs* regs) {
 #ifdef CONFIG_X86
@@ -79,10 +78,9 @@ inline unsigned long get_arg5(struct pt_regs* regs) {
 #endif
 }
 
-
 inline unsigned long get_return_address(struct pt_regs* regs) {
 #ifdef CONFIG_X86
-// NOT IMPLEMENTED FOR x86
+  // NOT IMPLEMENTED FOR x86
   return 0;
 #elif defined(CONFIG_ARM64)
   return regs->regs[30];
@@ -93,7 +91,6 @@ inline unsigned long get_return_address(struct pt_regs* regs) {
 #endif
 }
 
-
 extern char syscall_id_to_name[][32];
 extern handler_callback syscall_id_handlers[512];
 const unsigned long SYSCALL_TABLE_SIZE =
@@ -101,7 +98,7 @@ const unsigned long SYSCALL_TABLE_SIZE =
 
 // return the name by syscall number
 char* get_syscall_name(HASH_TABLE_ENTER* saved_entry) {
-  if (saved_entry== NULL || saved_entry->no >= SYSCALL_TABLE_SIZE ) {
+  if (saved_entry == NULL || saved_entry->no >= SYSCALL_TABLE_SIZE) {
     return "unknown";
   }
   return syscall_id_to_name[saved_entry->no];
@@ -109,8 +106,15 @@ char* get_syscall_name(HASH_TABLE_ENTER* saved_entry) {
 
 extern void init_syscall_id_handlers(void);
 
+static void append_return_address(struct handler_args* _handler_args) {
+  fast_sprintf(_handler_args->small_buf, "%lx, ",
+               get_return_address(_handler_args->regs));
+  _handler_args->small_buf += strlen(_handler_args->small_buf);
+}
+
 int gen_record_str(struct handler_args* _handler_args) {
-  if(_handler_args->saved_entry == NULL){
+  append_return_address(_handler_args);
+  if (_handler_args->saved_entry == NULL) {
     return default_handle(_handler_args);
   } else {
     return syscall_id_handlers[_handler_args->saved_entry->no](_handler_args);

--- a/syscalls/handlers-table.h
+++ b/syscalls/handlers-table.h
@@ -10,13 +10,13 @@ handler_callback functions[] = {
     &clone_handle,  &read_handle,     &mmap_handle,   &exit_group_handle,
     &close_handle,  &tgkill_handle,   &munmap_handle, &nanosleep_handle,
     &ppoll_handle,  &dup_handle,      &ioctl_handle,  &open_handle,
-    &creat_handle,  &openat_handle};
+    &creat_handle,  &openat_handle, &close_handle};
 
 char handler_string[][32] = {
     "getuid", "recvfrom", "socket", "fstat",     "getcwd", "lseek",
     "futex",  "sendto",   "clone",  "read",      "mmap",   "exit_group",
     "close",  "tgkill",   "munmap", "nanosleep", "ppoll",  "dup",
-    "ioctl",  "open",     "creat",  "openat"};
+    "ioctl",  "open",     "creat",  "openat", "close"};
 
 handler_callback syscall_id_handlers[512];
 

--- a/syscalls/handlers-table.h
+++ b/syscalls/handlers-table.h
@@ -10,13 +10,13 @@ handler_callback functions[] = {
     &clone_handle,  &read_handle,     &mmap_handle,   &exit_group_handle,
     &close_handle,  &tgkill_handle,   &munmap_handle, &nanosleep_handle,
     &ppoll_handle,  &dup_handle,      &ioctl_handle,  &open_handle,
-    &creat_handle,  &openat_handle, &close_handle};
+    &creat_handle,  &openat_handle, &close_handle, &writev_handle};
 
 char handler_string[][32] = {
     "getuid", "recvfrom", "socket", "fstat",     "getcwd", "lseek",
     "futex",  "sendto",   "clone",  "read",      "mmap",   "exit_group",
     "close",  "tgkill",   "munmap", "nanosleep", "ppoll",  "dup",
-    "ioctl",  "open",     "creat",  "openat", "close"};
+    "ioctl",  "open",     "creat",  "openat", "close", "writev"};
 
 handler_callback syscall_id_handlers[512];
 

--- a/syscalls/handlers.h
+++ b/syscalls/handlers.h
@@ -149,7 +149,7 @@ int read_handle(struct handler_args* _handler_args) {
           "pid=%d, read, fd=%d, size=%ld, res=%ld, data%s=%s\n", current->pid,
           fd, count, _handler_args->ret,
           (_handler_args->ret > ARGS_BUF_SIZE ? "(part)" : ""), buf_tmp);
-  return 0;
+  return 1;
 #else
   sprintf(_handler_args->small_buf,
           "pid=%d, read, fd=%d, size=%ld, res=%ld, data=", current->pid, fd,

--- a/syscalls/handlers.h
+++ b/syscalls/handlers.h
@@ -185,7 +185,7 @@ int close_handle(struct handler_args* _handler_args) {
   sprintf(_handler_args->small_buf, "pid=%d, close, fd=%d, res=%d\n",
           current->pid, (int)_handler_args->saved_entry->arg0,
           (int)_handler_args->ret);
-  return 0;
+  return -1;
 }
 
 int tgkill_handle(struct handler_args* _handler_args) {

--- a/syscalls/handlers.h
+++ b/syscalls/handlers.h
@@ -285,4 +285,9 @@ int openat_handle(struct handler_args* _handler_args) {
   return 0;
 }
 
+int writev_handle(struct handler_args* _handler_args){
+  default_handle(_handler_args);
+  return 1;
+}
+
 #endif

--- a/syscalls/handlers.h
+++ b/syscalls/handlers.h
@@ -225,7 +225,7 @@ int ppoll_handle(struct handler_args* _handler_args) {
   // revents=%hd\n",
   //         current->pid, fd, fds2[2], fds2[3]);
   sprintf(_handler_args->small_buf, "pid=%d, ppoll\n", current->pid);
-  return 0;
+  return 1;
 }
 
 int dup_handle(struct handler_args* _handler_args) {

--- a/syscalls/handlers.h
+++ b/syscalls/handlers.h
@@ -24,14 +24,15 @@ inline void assemble_buf_arg(char* tmp_buf, const void* buf_addr,
                              const size_t len) {
   size_t tmp = min(len, (size_t)ARGS_BUF_SIZE);
   // NOTE: the buf_addr pointer a user address...
-  strncpy_from_user(tmp_buf, buf_addr, tmp);
+  copy_from_user(tmp_buf, buf_addr, tmp);
+  
   tmp_buf[tmp] = '\0';
 }
 
 inline void assemble_struct_arg(void* dst_struct, const void* src_struct,
                                 const size_t len) {
   // NOTE: the buf_addr pointer a user address...
-  strncpy_from_user(dst_struct, src_struct, len);
+  copy_from_user(dst_struct, src_struct, len);
 }
 
 inline int default_handle(struct handler_args* _handler_args) {

--- a/syscalls/handlers.h
+++ b/syscalls/handlers.h
@@ -282,7 +282,7 @@ int openat_handle(struct handler_args* _handler_args) {
           "pid=%d, openat, dir=%d, path=%s, flags=%d, mode=%u, "
           "res=%d\n",
           current->pid, dirfd, buf_tmp, flags, mode, (int)_handler_args->ret);
-  return 0;
+  return 1;
 }
 
 int writev_handle(struct handler_args* _handler_args){

--- a/syscalls/handlers.h
+++ b/syscalls/handlers.h
@@ -1,5 +1,7 @@
 #ifndef _MYSYSDIG_HANDLERS_H
 #define _MYSYSDIG_HANDLERS_H
+
+// DO NOT COMMENT THIS DEFINE!!!
 #define TRUNCATE_CONTENT_RECORD
 #include <asm/ptrace.h>
 #define ARGS_BUF_SIZE 200
@@ -156,7 +158,7 @@ int read_handle(struct handler_args* _handler_args) {
   small_buf_len = strlen(_handler_args->small_buf);
   WRITE_FILE_LOCK();
   if (!check_offset(small_buf_len + _handler_args->ret + 1)) {
-    dump_to_file();
+    transfer_to_real_of_real_buffer();
   }
   syscall_count++;
 

--- a/syscalls/handlers.h
+++ b/syscalls/handlers.h
@@ -19,6 +19,7 @@ extern inline unsigned long get_arg2(struct pt_regs* regs);
 extern inline unsigned long get_arg3(struct pt_regs* regs);
 extern inline unsigned long get_arg4(struct pt_regs* regs);
 extern inline unsigned long get_arg5(struct pt_regs* regs);
+extern int fast_sprintf(char *, char *, ...);
 
 inline void assemble_buf_arg(char* tmp_buf, const void* buf_addr,
                              const size_t len) {
@@ -36,13 +37,13 @@ inline void assemble_struct_arg(void* dst_struct, const void* src_struct,
 }
 
 inline int default_handle(struct handler_args* _handler_args) {
-  sprintf(_handler_args->small_buf, "pid=%d, %s, res=%ld\n", current->pid,
+  fast_sprintf(_handler_args->small_buf, "pid=%d, %s, res=%ld\n", current->pid,
           get_syscall_name(_handler_args->saved_entry), _handler_args->ret);
   return 0;
 }
 
 int getuid_handle(struct handler_args* _handler_args) {
-  sprintf(_handler_args->small_buf, "pid=%d, gituid, res=0x%lx\n", current->pid,
+  fast_sprintf(_handler_args->small_buf, "pid=%d, gituid, res=0x%lx\n", current->pid,
           _handler_args->ret);
   return 0;
 }
@@ -54,7 +55,7 @@ int recvfrom_handle(struct handler_args* _handler_args) {
   // NOTE: need ARGS_BUF_SIZE + 1 to save '\0'
   char buf_tmp[ARGS_BUF_SIZE + 1];
   assemble_buf_arg(buf_tmp, buf, _handler_args->ret);
-  sprintf(_handler_args->small_buf,
+  fast_sprintf(_handler_args->small_buf,
           "pid=%d, %s, fd=%d, size=%ld, res=%ld, data%s=%s\n", current->pid,
           get_syscall_name(_handler_args->saved_entry), fd, count,
           _handler_args->ret,
@@ -67,7 +68,7 @@ inline int recv_handle(struct handler_args* _handler_args) {
 }
 
 int shutdown_handle(struct handler_args* _handler_args) {
-  sprintf(_handler_args->small_buf,
+  fast_sprintf(_handler_args->small_buf,
           "pid=%d, shutdown, sockfd=%d, how=%d, res=0x%d\n", current->pid,
           (int)_handler_args->saved_entry->arg0,
           (int)_handler_args->saved_entry->arg1, (int)_handler_args->ret);
@@ -77,7 +78,7 @@ int shutdown_handle(struct handler_args* _handler_args) {
 int socket_handle(struct handler_args* _handler_args) {
   int arg1 = _handler_args->saved_entry->arg1;
   int arg2 = get_arg2(_handler_args->regs);
-  sprintf(_handler_args->small_buf,
+  fast_sprintf(_handler_args->small_buf,
           "pid=%d, socket, domain=%ld, type=%d, protocal=%d, fd=%ld\n",
           current->pid, _handler_args->saved_entry->arg0, arg1, arg2,
           _handler_args->ret);
@@ -85,7 +86,7 @@ int socket_handle(struct handler_args* _handler_args) {
 }
 
 int fstat_handle(struct handler_args* _handler_args) {
-  sprintf(_handler_args->small_buf, "pid=%d, fstat, fd=%ld, res=%ld\n",
+  fast_sprintf(_handler_args->small_buf, "pid=%d, fstat, fd=%ld, res=%ld\n",
           current->pid, _handler_args->saved_entry->arg0, _handler_args->ret);
   return 0;
 }
@@ -95,10 +96,10 @@ int getcwd_handle(struct handler_args* _handler_args) {
   char buf_tmp[ARGS_BUF_SIZE + 1];
   if (res_p) {
     assemble_buf_arg(buf_tmp, res_p, ARGS_BUF_SIZE);
-    sprintf(_handler_args->small_buf, "pid=%d, getcwd, path=%s\n", current->pid,
+    fast_sprintf(_handler_args->small_buf, "pid=%d, getcwd, path=%s\n", current->pid,
             buf_tmp);
   } else {
-    sprintf(_handler_args->small_buf, "pid=%d, getcwd, ERROR\n", current->pid);
+    fast_sprintf(_handler_args->small_buf, "pid=%d, getcwd, ERROR\n", current->pid);
   }
   return 0;
 }
@@ -107,7 +108,7 @@ int lseek_handle(struct handler_args* _handler_args) {
   int fd = _handler_args->saved_entry->arg0;
   off_t offset = _handler_args->saved_entry->arg1;
   int whence = get_arg2(_handler_args->regs);
-  sprintf(_handler_args->small_buf,
+  fast_sprintf(_handler_args->small_buf,
           "pid=%d, lseek, fd=%d, offset=%ld, whence=%d, res=%ld\n",
           current->pid, fd, offset, whence, _handler_args->ret);
   return 0;
@@ -117,7 +118,7 @@ int futex_handle(struct handler_args* _handler_args) {
   uint32_t addr = _handler_args->saved_entry->arg0;
   int futex_op = _handler_args->saved_entry->arg1;
   uint32_t val = get_arg2(_handler_args->regs);
-  sprintf(_handler_args->small_buf,
+  fast_sprintf(_handler_args->small_buf,
           "pid=%d, futex, addr=%x, op=%d, val=%u, res=%ld\n", current->pid,
           addr, futex_op, val, _handler_args->ret);
   return 0;
@@ -125,14 +126,14 @@ int futex_handle(struct handler_args* _handler_args) {
 
 int sendto_handle(struct handler_args* _handler_args) {
   int sockfd = _handler_args->saved_entry->arg0;
-  sprintf(_handler_args->small_buf, "pid=%d, sendto, sockfd=%d, size=%ld\n",
+  fast_sprintf(_handler_args->small_buf, "pid=%d, sendto, sockfd=%d, size=%ld\n",
           current->pid, sockfd, _handler_args->ret);
   return 0;
 }
 
 int clone_handle(struct handler_args* _handler_args) {
   int pid = _handler_args->ret;
-  sprintf(_handler_args->small_buf, "pid=%d, clone, res=%d\n", current->pid,
+  fast_sprintf(_handler_args->small_buf, "pid=%d, clone, res=%d\n", current->pid,
           pid);
   return 0;
 }
@@ -146,13 +147,13 @@ int read_handle(struct handler_args* _handler_args) {
 #ifdef TRUNCATE_CONTENT_RECORD
   char buf_tmp[ARGS_BUF_SIZE + 1];
   assemble_buf_arg(buf_tmp, buf, _handler_args->ret);
-  sprintf(_handler_args->small_buf,
+  fast_sprintf(_handler_args->small_buf,
           "pid=%d, read, fd=%d, size=%ld, res=%ld, data%s=%s\n", current->pid,
           fd, count, _handler_args->ret,
           (_handler_args->ret > ARGS_BUF_SIZE ? "(part)" : ""), buf_tmp);
   return 1;
 #else
-  sprintf(_handler_args->small_buf,
+  fast_sprintf(_handler_args->small_buf,
           "pid=%d, read, fd=%d, size=%ld, res=%ld, data=", current->pid, fd,
           count, _handler_args->ret);
 
@@ -172,18 +173,18 @@ int read_handle(struct handler_args* _handler_args) {
 }
 
 int mmap_handle(struct handler_args* _handler_args) {
-  sprintf(_handler_args->small_buf, "pid=%d, mmap, res=0x%lx\n", current->pid,
+  fast_sprintf(_handler_args->small_buf, "pid=%d, mmap, res=0x%lx\n", current->pid,
           _handler_args->ret);
   return 0;
 }
 
 int exit_group_handle(struct handler_args* _handler_args) {
-  sprintf(_handler_args->small_buf, "pid=%d, exit_group\n", current->pid);
+  fast_sprintf(_handler_args->small_buf, "pid=%d, exit_group\n", current->pid);
   return 0;
 }
 
 int close_handle(struct handler_args* _handler_args) {
-  sprintf(_handler_args->small_buf, "pid=%d, close, fd=%d, res=%d\n",
+  fast_sprintf(_handler_args->small_buf, "pid=%d, close, fd=%d, res=%d\n",
           current->pid, (int)_handler_args->saved_entry->arg0,
           (int)_handler_args->ret);
   return 1;
@@ -193,7 +194,7 @@ int tgkill_handle(struct handler_args* _handler_args) {
   pid_t tgid = _handler_args->saved_entry->arg0;
   pid_t tid = _handler_args->saved_entry->arg1;
   int sig = get_arg2(_handler_args->regs);
-  sprintf(_handler_args->small_buf,
+  fast_sprintf(_handler_args->small_buf,
           "pid=%d, tgkill, tgid=%d, tid=%d, sig=%d, res=%d\n", current->pid,
           tgid, tid, sig, (int)_handler_args->ret);
   return 0;
@@ -202,7 +203,7 @@ int tgkill_handle(struct handler_args* _handler_args) {
 int munmap_handle(struct handler_args* _handler_args) {
   unsigned long addr = _handler_args->saved_entry->arg0;
   size_t length = _handler_args->saved_entry->arg1;
-  sprintf(_handler_args->small_buf,
+  fast_sprintf(_handler_args->small_buf,
           "pid=%d, munmap, addr=0x%lx, length=%ld, res=%d\n", current->pid,
           addr, length, (int)_handler_args->ret);
   return 0;
@@ -210,10 +211,10 @@ int munmap_handle(struct handler_args* _handler_args) {
 
 int nanosleep_handle(struct handler_args* _handler_args) {
   // struct timespec* req = (void*)_handler_args->saved_entry->arg0;
-  // sprintf(_handler_args->small_buf, "pid=%d, nanosleep, interval=%ld\n",
+  // fast_sprintf(_handler_args->small_buf, "pid=%d, nanosleep, interval=%ld\n",
   // current->pid,
   //         req->tv_nsec);
-  sprintf(_handler_args->small_buf, "pid=%d, nanosleep\n", current->pid);
+  fast_sprintf(_handler_args->small_buf, "pid=%d, nanosleep\n", current->pid);
   return 0;
 }
 
@@ -222,16 +223,16 @@ int ppoll_handle(struct handler_args* _handler_args) {
   // int* fds = (void*)_handler_args->saved_entry->arg0;
   // short* fds2 = (short*)fds;
   // int fd = *fds;
-  // sprintf(_handler_args->small_buf, "pid=%d, ppoll, fd=%d, events=%hd,
+  // fast_sprintf(_handler_args->small_buf, "pid=%d, ppoll, fd=%d, events=%hd,
   // revents=%hd\n",
   //         current->pid, fd, fds2[2], fds2[3]);
-  sprintf(_handler_args->small_buf, "pid=%d, ppoll\n", current->pid);
+  fast_sprintf(_handler_args->small_buf, "pid=%d, ppoll\n", current->pid);
   return 1;
 }
 
 int dup_handle(struct handler_args* _handler_args) {
   int oldfd = _handler_args->saved_entry->arg0;
-  sprintf(_handler_args->small_buf, "pid=%d, dup, oldfd=%d, res=%d\n",
+  fast_sprintf(_handler_args->small_buf, "pid=%d, dup, oldfd=%d, res=%d\n",
           current->pid, oldfd, (int)_handler_args->ret);
   return 0;
 }
@@ -240,7 +241,7 @@ int ioctl_handle(struct handler_args* _handler_args) {
   int fd = _handler_args->saved_entry->arg0;
   unsigned long req = _handler_args->saved_entry->arg1;
   unsigned long argp = get_arg2(_handler_args->regs);
-  sprintf(_handler_args->small_buf,
+  fast_sprintf(_handler_args->small_buf,
           "pid=%d, ioctl, fd=%d, req=%ld, argp=0x%lx, res=%d\n", current->pid,
           fd, req, argp, (int)_handler_args->ret);
   return 0;
@@ -253,7 +254,7 @@ int open_handle(struct handler_args* _handler_args) {
   char buf_tmp[ARGS_BUF_SIZE + 1];
 
   assemble_buf_arg(buf_tmp, pathname, ARGS_BUF_SIZE);
-  sprintf(_handler_args->small_buf,
+  fast_sprintf(_handler_args->small_buf,
           "pid=%d, open, path=%s, flags=%d, mode=%u, res=%d\n", current->pid,
           buf_tmp, flags, mode, (int)_handler_args->ret);
   return 0;
@@ -265,7 +266,7 @@ int creat_handle(struct handler_args* _handler_args) {
   char buf_tmp[ARGS_BUF_SIZE + 1];
 
   assemble_buf_arg(buf_tmp, pathname, ARGS_BUF_SIZE);
-  sprintf(_handler_args->small_buf, "pid=%d, creat, path=%s, mode=%u, res=%d\n",
+  fast_sprintf(_handler_args->small_buf, "pid=%d, creat, path=%s, mode=%u, res=%d\n",
           current->pid, buf_tmp, mode, (int)_handler_args->ret);
   return 0;
 }
@@ -279,7 +280,7 @@ int openat_handle(struct handler_args* _handler_args) {
   char buf_tmp[ARGS_BUF_SIZE + 1];
 
   assemble_buf_arg(buf_tmp, pathname, ARGS_BUF_SIZE);
-  sprintf(_handler_args->small_buf,
+  fast_sprintf(_handler_args->small_buf,
           "pid=%d, openat, dir=%d, path=%s, flags=%d, mode=%u, "
           "res=%d\n",
           current->pid, dirfd, buf_tmp, flags, mode, (int)_handler_args->ret);

--- a/syscalls/handlers.h
+++ b/syscalls/handlers.h
@@ -185,7 +185,7 @@ int close_handle(struct handler_args* _handler_args) {
   sprintf(_handler_args->small_buf, "pid=%d, close, fd=%d, res=%d\n",
           current->pid, (int)_handler_args->saved_entry->arg0,
           (int)_handler_args->ret);
-  return -1;
+  return 1;
 }
 
 int tgkill_handle(struct handler_args* _handler_args) {


### PR DESCRIPTION
This update includes many fundamental functions changing:
- use `fast_sprintf` instead of `sprintf` provided by Linux (also, use `memcpy` rather than `strncpy`)
- add a secondary buffer to save data when the primary buffer full, as we have found that we cannot write the file in certain syscalls (#9).
- add a record for return address (so that the developer can identify where the syscall issued), but still not supported for x86 (#11)
- maintain 10 file descriptors instead of one, to bypass the single file writing limitation (#7)